### PR TITLE
Add extra debugging in mysqld script

### DIFF
--- a/mysqld.sh
+++ b/mysqld.sh
@@ -29,6 +29,11 @@ function check_nodes {
 	return 1
 }
 
+# Set 'TRACE=y' environment variable to see detailed output for debugging
+if [ "$TRACE" = "y" ]; then
+	set -x
+fi
+
 if [[ "$OPT" =~ /--wsrep-new-cluster/ ]]
 then
 	# --wsrep-new-cluster is used for the "seed" command so no recovery used


### PR DESCRIPTION
`mysqld.sh` script does not honor the `set -x` command in the parent `start.sh`. This simply allows `TRACE=y` to output debug info from all commands, rather than the initial start script.