### PR TITLE
Fixed ip address lookup for eth0

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -22,7 +22,7 @@ if [ -z "$NODE_ADDRESS" ]; then
 fi
 if [ -z "$NODE_ADDRESS" ]; then
 	# Support Docker Swarm Mode
-	NODE_ADDRESS=$(ip addr | awk '/inet/ && /eth0/{sub(/\/.*$/,"",$2); print $2}')
+	NODE_ADDRESS=$(ip addr | awk '/inet/ && /eth0/{sub(/\/.*$/,"",$2); print $2}' | head -n 1)
 elif [[ "$NODE_ADDRESS" =~ [a-zA-Z][a-zA-Z0-9:]+ ]]; then
 	# Support interface - e.g. Docker Swarm Mode uses eth0
 	NODE_ADDRESS=$(ip addr | awk "/inet/ && / $NODE_ADDRESS\$/{sub(/\\/.*$/,\"\",\$2); print \$2}" | head -n 1)


### PR DESCRIPTION
`ip addr show eth0` output sometimes contains several ip addresses

```
root@d9592ddc3f54:/# ip addr show eth0                                                             
2759: eth0@if2760: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default 
    link/ether 02:42:0a:00:00:05 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 10.0.0.5/24 scope global eth0
       valid_lft forever preferred_lft forever
    inet 10.0.0.4/32 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:aff:fe00:5/64 scope link 
       valid_lft forever preferred_lft forever
```

and the `start.sh` script incorrectly parses them

```
root@d9592ddc3f54:/# ip addr | awk '/inet/ && /eth0/{sub(/\/.*$/,"",$2); print $2}'
10.0.0.5
10.0.0.4
```

The PR fixes it by taking the first ip address from the output.