### PR TITLE
Support reading secrets from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It takes as a command one of the following:
    and resetting root credentials.
  - "sleep" - Start the container but not the server. Runs "sleep infinity". Useful just to get volumes
    initialized or if you want to `docker exec` without the server running.
- 
+
 The main feature over the official maraiadb image is that DNS-resolution is used to discover other nodes
 so they don't have to be specified explicitly. Works with any system with DNS-based service discovery such
 as Kontena, Docker Swarm Mode, Consul, etc.
@@ -31,7 +31,7 @@ as Kontena, Docker Swarm Mode, Consul, etc.
 
 ### Environment Variables
 
- - `XTRABACKUP_PASSWORD` (required)
+ - `XTRABACKUP_PASSWORD` (required unless `XTRABACKUP_PASSWORD_FILE` is provided)
  - `SYSTEM_PASSWORD` (optional - defaults to hash of `XTRABACKUP_PASSWORD`)
  - `CLUSTER_NAME` (optional)
  - `NODE_ADDRESS` (optional - defaults to ethwe, then eth0)
@@ -47,6 +47,18 @@ Additional variables for "node":
 
  - `GCOMM_MINIMUM` (optional - defaults to 2)
 
+#### Providing secrets through files
+
+It's also possible to configure the sensitive variables (especially passwords)
+by providing files. This makes it easier, for example, to integrate with
+[Docker Swarm's secret support](https://docs.docker.com/engine/swarm/secrets/)
+added in Docker 1.13.0.
+
+The path to the secret file must be provided in environment variables:
+- `XTRABACKUP_PASSWORD_FILE` (required unless `XTRABACKUP_PASSWORD` provided)
+- `SYSTEM_PASSWORD_FILE` (optional - defaults to hash of `XTRABACKUP_PASSWORD`)
+- `MYSQL_ROOT_PASSWORD_FILE` (optional)
+- `MYSQL_PASSWORD_FILE` (optional)
 
 ### Health Checks
 

--- a/start.sh
+++ b/start.sh
@@ -40,6 +40,20 @@ fi
 echo "---===--- MariaDB Galera Start Script ---===---"
 echo "Got NODE_ADDRESS=$NODE_ADDRESS"
 
+# Read optional secrets from files
+if [ -z $XTRABACKUP_PASSWORD ] && [ -f $XTRABACKUP_PASSWORD_FILE ]; then
+	XTRABACKUP_PASSWORD=$(cat $XTRABACKUP_PASSWORD_FILE)
+fi
+if [ -z $SYSTEM_PASSWORD ] && [ -f $SYSTEM_PASSWORD_FILE ]; then
+	SYSTEM_PASSWORD=$(cat $SYSTEM_PASSWORD_FILE)
+fi
+if [ -z $MYSQL_ROOT_PASSWORD ] && [ -f $MYSQL_ROOT_PASSWORD_FILE ]; then
+	MYSQL_ROOT_PASSWORD=$(cat $MYSQL_ROOT_PASSWORD_FILE)
+fi
+if [ -z $MYSQL_PASSWORD ] && [ -f $MYSQL_PASSWORD_FILE ]; then
+	MYSQL_PASSWORD=$(cat $MYSQL_PASSWORD_FILE)
+fi
+
 # System password defaults to hash of xtrabackup password
 if test -n "$XTRABACKUP_PASSWORD"; then
 	SYSTEM_PASSWORD=${SYSTEM_PASSWORD:-$(echo "$XTRABACKUP_PASSWORD" | sha256sum | awk '{print $1;}')}


### PR DESCRIPTION
It's beneficial sometimes to pass secrets in via files, rather than environment variables.

Also, this enables the use of the new secret management support in Docker Swarm mode in Docker 1.13.0 (https://docs.docker.com/engine/swarm/secrets/).

I've tested this with a temporary image ([`hairyhenderson/mgs`](https://hub.docker.com/r/hairyhenderson/mgs/)), and the database seems to start up properly.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>