### PR TITLE
Allow additional initialisation scripts in /docker-entrypoint-initdb.d

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -166,6 +166,17 @@ EOF
 	fi
 	echo "FLUSH PRIVILEGES;" >> /tmp/bootstrap.sql
 
+	# Add additional database initialization scripts
+        for f in /docker-entrypoint-initdb.d/*; do
+                case "$f" in
+                        *.sh)     echo "$0: running $f"; . "$f" ;;
+                        *.sql)    echo "$0: appending $f"; cat "$f" >> /tmp/bootstrap.sql ;;
+                        *.sql.gz) echo "$0: appending $f"; gunzip -c "$f" >> /tmp/bootstrap.sql ;;
+                        *)        echo "$0: ignoring $f" ;;
+                esac
+                echo
+        done
+
 	# Add timezone info
 	mysql_tzinfo_to_sql /usr/share/zoneinfo >> /tmp/bootstrap.sql
 


### PR DESCRIPTION
This adds the upstream changes from MySql and MariaDb which allow additional initialisation scripts of various types to be loaded from /docker-entrypoint-initdb.d.

This folder is already created in the base MariaDb image and it can be accessed via a docker volume in a docker-compose.yml file or docker service command.