### PR TITLE
[master]

### DIFF
--- a/examples/swarm/README.md
+++ b/examples/swarm/README.md
@@ -20,3 +20,5 @@ $ docker service scale galera_node=3
 Note, currently I do not know of a good way to retrieve the DNS name to lookup other IPs so the
 `docker-compose.yml` file has `galera_seed,galera_node` hard-coded which would not work unless
 `galera` is used as the name of the stack for the `docker stack deploy` command.
+
+For similar reasons, the example `docker-compose.yml` file contains a user network called `galera_network`. The name of this network is not critical, but it needs to be first in the list of user defined overlay networks in `docker-compose.yml`, so that Docker allocates it the subnet 10.0.0.0/24. This is required so that the `NODE_ADDRESS=^10.0.0.*` pattern matching works when the seed and node containers are started.

--- a/examples/swarm/docker-compose.yml
+++ b/examples/swarm/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - XTRABACKUP_PASSWORD_FILE=/run/secrets/xtrabackup_password
       - NODE_ADDRESS=^10.0.0.*
       - HEALTHY_WHILE_BOOTING=1
+    networks:
+      - galera_network
     command: node galera_seed,galera_node
     deploy:
       replicas: 0

--- a/examples/swarm/docker-compose.yml
+++ b/examples/swarm/docker-compose.yml
@@ -9,7 +9,9 @@ services:
       - MYSQL_PASSWORD_FILE=/run/secrets/mysql_password
       - MYSQL_DATABASE=database
       - MYSQL_ROOT_PASSWORD_FILE=/run/secrets/mysql_root_password
-      - NODE_ADDRESS=eth0
+      - NODE_ADDRESS=^10.0.0.*
+    networks:
+      - galera_network
     command: seed
     volumes:
       - mysql-data:/var/lib/mysql
@@ -21,7 +23,7 @@ services:
     image: colinmollenhour/mariadb-galera-swarm
     environment:
       - XTRABACKUP_PASSWORD_FILE=/run/secrets/xtrabackup_password
-      - NODE_ADDRESS=eth0
+      - NODE_ADDRESS=^10.0.0.*
       - HEALTHY_WHILE_BOOTING=1
     command: node galera_seed,galera_node
     deploy:
@@ -32,6 +34,10 @@ services:
 volumes:
   mysql-data:
     driver: local
+
+networks:
+  galera_network:
+    driver: overlay
 
 secrets:
   xtrabackup_password:

--- a/start.sh
+++ b/start.sh
@@ -68,7 +68,7 @@ elif [[ "$NODE_ADDRESS" =~ [a-zA-Z][a-zA-Z0-9:]+ ]]; then
 	NODE_ADDRESS=$(ip addr | awk "/inet/ && / $NODE_ADDRESS\$/{sub(/\\/.*$/,\"\",\$2); print \$2}" | head -n 1)
 elif ! [[ "$NODE_ADDRESS" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	# Support grep pattern. E.g. ^10.0.1.*
-	NODE_ADDRESS=$(getent hosts $(hostname) | grep -e "$NODE_ADDRESS") | awk '{print $1}'
+	NODE_ADDRESS=$(getent hosts $(hostname) | grep -e "$NODE_ADDRESS" | awk '{print $1}')
 fi
 if ! [[ "$NODE_ADDRESS" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	echo "Could not determine NODE_ADDRESS: $NODE_ADDRESS"

--- a/start.sh
+++ b/start.sh
@@ -68,7 +68,7 @@ elif [[ "$NODE_ADDRESS" =~ [a-zA-Z][a-zA-Z0-9:]+ ]]; then
 	NODE_ADDRESS=$(ip addr | awk "/inet/ && / $NODE_ADDRESS\$/{sub(/\\/.*$/,\"\",\$2); print \$2}" | head -n 1)
 elif ! [[ "$NODE_ADDRESS" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	# Support grep pattern. E.g. ^10.0.1.*
-	NODE_ADDRESS=$(getent hosts $(hostname) | grep -e "$NODE_ADDRESS")
+	NODE_ADDRESS=$(getent hosts $(hostname) | grep -e "$NODE_ADDRESS") | awk '{print $1}'
 fi
 if ! [[ "$NODE_ADDRESS" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	echo "Could not determine NODE_ADDRESS: $NODE_ADDRESS"


### PR DESCRIPTION
See Issue #20 

Added " awk '{print $1}' " to line 71 of start.sh
This is necessary because getent hosts $(hostname) returns
the ip address followed by the host name and we only want the
ip address
The second commit corrects a typo and is required.

The third commit are suggested changes to docker-compose.yml & README.md, and is optional.
The fourth commit corrects a typo in the third commit.