### PR TITLE
swarm: docker dns already knows service names

### DIFF
--- a/examples/swarm/README.md
+++ b/examples/swarm/README.md
@@ -17,11 +17,7 @@ $ docker service scale galera_seed=0
 $ docker service scale galera_node=3
 ```
 
-Note, currently I do not know of a good way to retrieve the DNS name to lookup other IPs so the
-`docker-compose.yml` file has `galera_seed,galera_node` hard-coded which would not work unless
-`galera` is used as the name of the stack for the `docker stack deploy` command.
-
-For similar reasons, the example `docker-compose.yml` file contains a user network called `galera_network`. The name of this network is not critical, but it needs to be first in the list of user defined overlay networks in `docker-compose.yml`, so that Docker allocates it the subnet 10.0.0.0/24. This is required so that the `NODE_ADDRESS=^10.0.0.*` pattern matching works when the seed and node containers are started.
+The example `docker-compose.yml` file contains a user network called `galera_network`. The name of this network is not critical, but it needs to be first in the list of user defined overlay networks in `docker-compose.yml`, so that Docker allocates it the subnet 10.0.0.0/24. This is required so that the `NODE_ADDRESS=^10.0.0.*` pattern matching works when the seed and node containers are started.
 
 If you want to use a different subnet address for this user network, then it should be created first and the network type in `docker-compose.yml` should be changed to `external`. The `NODE_ADDRESS` pattern should also be updated to this new address. For example, if the new subnet address is `10.0.9.0` then change it to `NODE_ADDRESS=^10.0.9.*`.
 

--- a/examples/swarm/docker-compose.yml
+++ b/examples/swarm/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - HEALTHY_WHILE_BOOTING=1
     networks:
       - galera_network
-    command: node galera_seed,galera_node
+    command: node seed,node
     deploy:
       replicas: 0
     secrets:


### PR DESCRIPTION
The docker swarm stack also knows stack internal names without the stack name prepended:

```sh
root@docker-swarm-node-xxx:~# docker exec -it galera_seed.1.xxx /bin/bash
root@xxx:/# getent hosts seed   
10.0.10.2       seed
root@xxx:/# getent hosts galera_seed
10.0.10.2       galera_seed
```

Note: I've created an external network, that's why it's `10.0.10.0/24`