### PR TITLE
sst-method can be specified as environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ EXPOSE 3306 4444 4567 4567/udp 4568 8080 8081
 
 HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
 
+ENV SST_METHOD=xtrabackup-v2
+
 ENTRYPOINT ["start.sh"]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please submit more examples for Kubernetes, Mesos, etc. and also improvements fo
 ### Environment Variables
 
  - `XTRABACKUP_PASSWORD` (required unless `XTRABACKUP_PASSWORD_FILE` is provided)
- - `SYSTEM_PASSWORD` (optional - defaults to hash of `XTRABACKUP_PASSWORD`)
+ - `SYSTEM_PASSWORD` (required or set to a hash of `XTRABACKUP_PASSWORD` if provided.)
  - `CLUSTER_NAME` (optional)
  - `NODE_ADDRESS` (optional - defaults to ethwe, then eth0)
  - `LISTEN_WHEN_HEALTHY` (optional) - Specify a port number to open a healthcheck socket on once the cluster

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Please submit more examples for Kubernetes, Mesos, etc. and also improvements fo
  - `HEALTHY_WHILE_BOOTING` (optional) - If '1' then the HEALTHCHECK script will report healthy
    during the boot phase (waiting for DNS to resolve and recovering wsrep position).
  - `SKIP_TZINFO` (optional) - Specify any value to skip loading of timezone table data when initing a new directory.
+ - `SST_METHOD` (optional - defaults to 'xtrabackup-v2')  May be set to 'rsync' or 'mysqldump'.  Other methods requiring further configuration or installed dependencies are not available in this image.
 
 Additional variables for "seed":
 

--- a/conf.d/galera.cnf
+++ b/conf.d/galera.cnf
@@ -19,7 +19,7 @@ wsrep_provider=/usr/lib/galera/libgalera_smm.so
 #
 # xtrabackup-v2 allows for faster SST
 #
-wsrep_sst_method=xtrabackup-v2
+#wsrep_sst_method=xtrabackup-v2
 [sst]
 sst-syslog=-1
 #progress=/tmp/mysql-console/fifo

--- a/start.sh
+++ b/start.sh
@@ -202,7 +202,7 @@ fi
 #
 case $START_MODE in
 	seed)
-		MYSQL_MODE_ARGS+=" --wsrep-on=ON --wsrep-new-cluster"
+		MYSQL_MODE_ARGS+=" --wsrep-on=ON --wsrep-new-cluster --wsrep-sst-method=$SST_METHOD"
 		echo "Starting seed node"
 	;;
 	node)
@@ -212,7 +212,7 @@ case $START_MODE in
 			echo "List of nodes addresses/hostnames required"
 			exit 1
 		fi
-		MYSQL_MODE_ARGS+=" --wsrep-on=ON"
+		MYSQL_MODE_ARGS+=" --wsrep-on=ON --wsrep-sst-method=$SST_METHOD"
 		RESOLVE=0
 		SLEEPS=0
 

--- a/start.sh
+++ b/start.sh
@@ -92,24 +92,38 @@ fi
 echo "...------======------... MariaDB Galera Start Script ...------======------..."
 echo "Got NODE_ADDRESS=$NODE_ADDRESS"
 
+MYSQL_MODE_ARGS=""
+
 #
 # Read optional secrets from files
 #
-XTRABACKUP_PASSWORD_FILE=${XTRABACKUP_PASSWORD_FILE:-/run/secrets/xtrabackup_password}
-SYSTEM_PASSWORD_FILE=${SYSTEM_PASSWORD_FILE:-/run/secrets/system_password}
-if [ -z $XTRABACKUP_PASSWORD ] && [ -f $XTRABACKUP_PASSWORD_FILE ]; then
+
+# mode is xtrabackup?
+if [[ $SST_MODE =~ ^xtrabackup.*$ ]] ; then
+  XTRABACKUP_PASSWORD_FILE=${XTRABACKUP_PASSWORD_FILE:-/run/secrets/xtrabackup_password}
+  if [ -z $XTRABACKUP_PASSWORD ] && [ -f $XTRABACKUP_PASSWORD_FILE ]; then
 	XTRABACKUP_PASSWORD=$(cat $XTRABACKUP_PASSWORD_FILE)
+  fi
+  [ -z "$XTRABACKUP_PASSWORD" ] && { echo "XTRABACKUP_PASSWORD not set"; exit 1; }
+  MYSQL_MODE_ARGS+=" --wsrep_sst_auth=xtrabackup:$XTRABACKUP_PASSWORD" 
 fi
-[ -z "$XTRABACKUP_PASSWORD" ] && { echo "XTRABACKUP_PASSWORD not set"; exit 1; }
+
+SYSTEM_PASSWORD_FILE=${SYSTEM_PASSWORD_FILE:-/run/secrets/system_password}
 if [ -z $SYSTEM_PASSWORD ] && [ -f $SYSTEM_PASSWORD_FILE ]; then
 	SYSTEM_PASSWORD=$(cat $SYSTEM_PASSWORD_FILE)
 fi
-[ -z "$SYSTEM_PASSWORD" ] && SYSTEM_PASSWORD=$(echo "$XTRABACKUP_PASSWORD" | sha256sum | awk '{print $1;}')
+if [ -z "$SYSTEM_PASSWORD" ] ; then
+  if [ -z "$XTRABACKUP_PASSWORD" ] ; then
+     SYSTEM_PASSWORD= $(echo "$XTRABACKUP_PASSWORD" | sha256sum | awk '{print $1;}')
+  else
+     echo "SYSTEM_PASSWORD not set"
+     exit 1
+  fi
+fi
 
 CLUSTER_NAME=${CLUSTER_NAME:-cluster}
 GCOMM_MINIMUM=${GCOMM_MINIMUM:-2}
 GCOMM=""
-MYSQL_MODE_ARGS=""
 
 # Hold startup until the flag file is deleted
 if [[ -f /var/lib/mysql/hold-start ]]; then
@@ -152,9 +166,13 @@ then
 		echo "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD"
 	fi
 
-	cat >/tmp/bootstrap.sql <<EOF
+	if [[ $SST_MODE =~ ^xtrabackup.*$ ]] ; then
+		cat >/tmp/bootstrap.sql <<EOF
 CREATE USER IF NOT EXISTS 'xtrabackup'@'%' IDENTIFIED BY '$XTRABACKUP_PASSWORD';
 GRANT RELOAD,LOCK TABLES,REPLICATION CLIENT ON *.* TO 'xtrabackup'@'%';
+EOF
+	fi
+	cat >>/tmp/bootstrap.sql <<EOF
 CREATE USER IF NOT EXISTS 'system'@'127.0.0.1' IDENTIFIED BY '$SYSTEM_PASSWORD';
 GRANT PROCESS,SHUTDOWN ON *.* TO 'system'@'127.0.0.1';
 CREATE USER IF NOT EXISTS 'system'@'localhost' IDENTIFIED BY '$SYSTEM_PASSWORD';
@@ -314,7 +332,6 @@ gosu mysql mysqld.sh --console \
 	--wsrep_cluster_name=$CLUSTER_NAME \
 	--wsrep_cluster_address=gcomm://$GCOMM \
 	--wsrep_node_address=$NODE_ADDRESS:4567 \
-	--wsrep_sst_auth=xtrabackup:$XTRABACKUP_PASSWORD \
 	--default-time-zone=+00:00 \
 	"$@" 2>&1 &
 wait $! || true


### PR DESCRIPTION
Given: no galera sst method suits all use cases.

Hence, allow the sst method to be configurable by environment variable.