### PR TITLE
Added the `DEFAULT_TIME_ZONE` variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ EXPOSE 3306 4444 4567 4567/udp 4568 8080 8081
 
 HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
 
+ENV SST_METHOD=xtrabackup-v2
+
 ENTRYPOINT ["start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
       curl \
+      netcat \
       pigz \
       percona-toolkit \
       pv \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please submit more examples for Kubernetes, Mesos, etc. and also improvements fo
 ### Environment Variables
 
  - `XTRABACKUP_PASSWORD` (required unless `XTRABACKUP_PASSWORD_FILE` is provided)
- - `SYSTEM_PASSWORD` (optional - defaults to hash of `XTRABACKUP_PASSWORD`)
+ - `SYSTEM_PASSWORD` (required or set to a hash of `XTRABACKUP_PASSWORD` if provided.)
  - `CLUSTER_NAME` (optional)
  - `NODE_ADDRESS` (optional - defaults to ethwe, then eth0)
  - `LISTEN_WHEN_HEALTHY` (optional) - Specify a port number to open a healthcheck socket on once the cluster

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Please submit more examples for Kubernetes, Mesos, etc. and also improvements fo
  - `HEALTHY_WHILE_BOOTING` (optional) - If '1' then the HEALTHCHECK script will report healthy
    during the boot phase (waiting for DNS to resolve and recovering wsrep position).
  - `SKIP_TZINFO` (optional) - Specify any value to skip loading of timezone table data when initing a new directory.
+ - `DEFAULT_TIME_ZONE` (optional - defaults to the `TZ` envvar or to '+00:00' if undefined) - Specify the database's time zone, either in numeric format (+01:00) or in verbal format (CET, Europe/Bratislava, etc.). The latter one is possible only if you haven't specified `SKIP_TZINFO`. More information about why you would need this is [here](https://mariadb.com/kb/en/library/time-zones/).
  - `SST_METHOD` (optional - defaults to 'xtrabackup-v2')  May be set to 'rsync' or 'mysqldump'.  Other methods requiring further configuration or installed dependencies are not available in this image.
 
 Additional variables for "seed":

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Please submit more examples for Kubernetes, Mesos, etc. and also improvements fo
  - `HEALTHY_WHILE_BOOTING` (optional) - If '1' then the HEALTHCHECK script will report healthy
    during the boot phase (waiting for DNS to resolve and recovering wsrep position).
  - `SKIP_TZINFO` (optional) - Specify any value to skip loading of timezone table data when initing a new directory.
+ - `SST_METHOD` (optional - defaults to 'xtrabackup-v2')  May be set to 'rsync' or 'mysqldump'.  Other methods requiring further configuration or installed dependencies are not available in this image.
 
 Additional variables for "seed":
 

--- a/conf.d/galera.cnf
+++ b/conf.d/galera.cnf
@@ -22,7 +22,7 @@ wsrep_provider=/usr/lib/galera/libgalera_smm.so
 wsrep_sst_method=xtrabackup-v2
 [sst]
 sst-syslog=-1
-progress=/tmp/mysql-console/fifo
+#progress=/tmp/mysql-console/fifo
 #inno-apply-opts="--use-memory=2G"
-#compressor="pigz --fast --processes 4"
-#decompressor="pigz --decompress"
+#compressor=pigz-compress-fast-2.sh
+#decompressor=pigz-decompress.sh

--- a/conf.d/galera.cnf
+++ b/conf.d/galera.cnf
@@ -19,7 +19,7 @@ wsrep_provider=/usr/lib/galera/libgalera_smm.so
 #
 # xtrabackup-v2 allows for faster SST
 #
-wsrep_sst_method=xtrabackup-v2
+#wsrep_sst_method=xtrabackup-v2
 [sst]
 sst-syslog=-1
 #progress=/tmp/mysql-console/fifo

--- a/pigz-compress-fast-2.sh
+++ b/pigz-compress-fast-2.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# my_print_defaults does not quote spaces in config values which breaks wsrep_sst_common
+# See https://github.com/MariaDB/server/pull/617
+pigz --fast --processes 2

--- a/pigz-compress-fast-4.sh
+++ b/pigz-compress-fast-4.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# my_print_defaults does not quote spaces in config values which breaks wsrep_sst_common
+# See https://github.com/MariaDB/server/pull/617
+pigz --fast --processes 4

--- a/pigz-decompress.sh
+++ b/pigz-decompress.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# my_print_defaults does not quote spaces in config values which breaks wsrep_sst_common
+# See https://github.com/MariaDB/server/pull/617
+pigz --decompress

--- a/start.sh
+++ b/start.sh
@@ -202,7 +202,7 @@ fi
 #
 case $START_MODE in
 	seed)
-		MYSQL_MODE_ARGS+=" --wsrep-on=ON --wsrep-new-cluster"
+		MYSQL_MODE_ARGS+=" --wsrep-on=ON --wsrep-new-cluster --wsrep-sst-method=$SST_METHOD"
 		echo "Starting seed node"
 	;;
 	node)
@@ -212,7 +212,7 @@ case $START_MODE in
 			echo "List of nodes addresses/hostnames required"
 			exit 1
 		fi
-		MYSQL_MODE_ARGS+=" --wsrep-on=ON"
+		MYSQL_MODE_ARGS+=" --wsrep-on=ON --wsrep-sst-method=$SST_METHOD"
 		RESOLVE=0
 		SLEEPS=0
 

--- a/start.sh
+++ b/start.sh
@@ -153,10 +153,8 @@ then
 	fi
 
 	cat >/tmp/bootstrap.sql <<EOF
-CREATE USER IF NOT EXISTS 'xtrabackup'@'127.0.0.1' IDENTIFIED BY '$XTRABACKUP_PASSWORD';
-GRANT RELOAD,LOCK TABLES,REPLICATION CLIENT ON *.* TO 'xtrabackup'@'127.0.0.1';
-CREATE USER IF NOT EXISTS 'xtrabackup'@'localhost' IDENTIFIED BY '$XTRABACKUP_PASSWORD';
-GRANT RELOAD,LOCK TABLES,REPLICATION CLIENT ON *.* TO 'xtrabackup'@'localhost';
+CREATE USER IF NOT EXISTS 'xtrabackup'@'%' IDENTIFIED BY '$XTRABACKUP_PASSWORD';
+GRANT RELOAD,LOCK TABLES,REPLICATION CLIENT ON *.* TO 'xtrabackup'@'%';
 CREATE USER IF NOT EXISTS 'system'@'127.0.0.1' IDENTIFIED BY '$SYSTEM_PASSWORD';
 GRANT PROCESS,SHUTDOWN ON *.* TO 'system'@'127.0.0.1';
 CREATE USER IF NOT EXISTS 'system'@'localhost' IDENTIFIED BY '$SYSTEM_PASSWORD';
@@ -242,6 +240,11 @@ case $START_MODE in
 			done
 			GCOMM=${GCOMM%%,}                        # strip trailing commas
 			GCOMM=$(echo "$GCOMM" | sed 's/,\+/,/g') # strip duplicate commas
+
+			# Allow user to bypass waiting for other IPs
+			if [[ -f /var/lib/mysql/skip-gcomm-wait ]]; then
+				break
+			fi
 
 			# It is possible that containers on other nodes aren't running yet and should be waited on
 			# before trying to start. For example, this occurs when updated container images are being pulled

--- a/start.sh
+++ b/start.sh
@@ -92,24 +92,38 @@ fi
 echo "...------======------... MariaDB Galera Start Script ...------======------..."
 echo "Got NODE_ADDRESS=$NODE_ADDRESS"
 
+MYSQL_MODE_ARGS=""
+
 #
 # Read optional secrets from files
 #
-XTRABACKUP_PASSWORD_FILE=${XTRABACKUP_PASSWORD_FILE:-/run/secrets/xtrabackup_password}
-SYSTEM_PASSWORD_FILE=${SYSTEM_PASSWORD_FILE:-/run/secrets/system_password}
-if [ -z $XTRABACKUP_PASSWORD ] && [ -f $XTRABACKUP_PASSWORD_FILE ]; then
+
+# mode is xtrabackup?
+if [[ $SST_MODE =~ ^xtrabackup.*$ ]] ; then
+  XTRABACKUP_PASSWORD_FILE=${XTRABACKUP_PASSWORD_FILE:-/run/secrets/xtrabackup_password}
+  if [ -z $XTRABACKUP_PASSWORD ] && [ -f $XTRABACKUP_PASSWORD_FILE ]; then
 	XTRABACKUP_PASSWORD=$(cat $XTRABACKUP_PASSWORD_FILE)
+  fi
+  [ -z "$XTRABACKUP_PASSWORD" ] && { echo "XTRABACKUP_PASSWORD not set"; exit 1; }
+  MYSQL_MODE_ARGS+=" --wsrep_sst_auth=xtrabackup:$XTRABACKUP_PASSWORD" 
 fi
-[ -z "$XTRABACKUP_PASSWORD" ] && { echo "XTRABACKUP_PASSWORD not set"; exit 1; }
+
+SYSTEM_PASSWORD_FILE=${SYSTEM_PASSWORD_FILE:-/run/secrets/system_password}
 if [ -z $SYSTEM_PASSWORD ] && [ -f $SYSTEM_PASSWORD_FILE ]; then
 	SYSTEM_PASSWORD=$(cat $SYSTEM_PASSWORD_FILE)
 fi
-[ -z "$SYSTEM_PASSWORD" ] && SYSTEM_PASSWORD=$(echo "$XTRABACKUP_PASSWORD" | sha256sum | awk '{print $1;}')
+if [ -z "$SYSTEM_PASSWORD" ] ; then
+  if [ -z "$XTRABACKUP_PASSWORD" ] ; then
+     SYSTEM_PASSWORD= $(echo "$XTRABACKUP_PASSWORD" | sha256sum | awk '{print $1;}')
+  else
+     echo "SYSTEM_PASSWORD not set"
+     exit 1
+  fi
+fi
 
 CLUSTER_NAME=${CLUSTER_NAME:-cluster}
 GCOMM_MINIMUM=${GCOMM_MINIMUM:-2}
 GCOMM=""
-MYSQL_MODE_ARGS=""
 
 # Hold startup until the flag file is deleted
 if [[ -f /var/lib/mysql/hold-start ]]; then
@@ -152,9 +166,13 @@ then
 		echo "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD"
 	fi
 
-	cat >/tmp/bootstrap.sql <<EOF
+	if [[ $SST_MODE =~ ^xtrabackup.*$ ]] ; then
+		cat >/tmp/bootstrap.sql <<EOF
 CREATE USER IF NOT EXISTS 'xtrabackup'@'%' IDENTIFIED BY '$XTRABACKUP_PASSWORD';
 GRANT RELOAD,LOCK TABLES,REPLICATION CLIENT ON *.* TO 'xtrabackup'@'%';
+EOF
+	fi
+	cat >>/tmp/bootstrap.sql <<EOF
 CREATE USER IF NOT EXISTS 'system'@'127.0.0.1' IDENTIFIED BY '$SYSTEM_PASSWORD';
 GRANT PROCESS,SHUTDOWN ON *.* TO 'system'@'127.0.0.1';
 CREATE USER IF NOT EXISTS 'system'@'localhost' IDENTIFIED BY '$SYSTEM_PASSWORD';
@@ -314,7 +332,6 @@ gosu mysql mysqld.sh --console \
 	--wsrep_cluster_name=$CLUSTER_NAME \
 	--wsrep_cluster_address=gcomm://$GCOMM \
 	--wsrep_node_address=$NODE_ADDRESS:4567 \
-	--wsrep_sst_auth=xtrabackup:$XTRABACKUP_PASSWORD \
 	--default-time-zone=+00:00 \
 	"$@" 2>&1 &
 wait $! || true

--- a/start.sh
+++ b/start.sh
@@ -25,6 +25,33 @@ if [ "$TRACE" = "y" ]; then
 	set -x
 fi
 
+# Set MariaDB's time zone
+if [[ -n $SKIP_TZINFO ]]; then
+    # We're skipping timezone tables population, so we restrict the
+    # timezone format to numeric.
+    DEFAULT_TIME_ZONE=${DEFAULT_TIME_ZONE:-"+00:00"}
+
+    if [[ $DEFAULT_TIME_ZONE != *":"* ]]; then
+		echo "Timezone '$DEFAULT_TIME_ZONE' cannot be used, because 'SKIP_TZINFO' is set. Falling back to default."
+        DEFAULT_TIME_ZONE="+00:00"
+    fi
+else
+    # If we're populating timezone tables, we are able to use both verbal and
+    # numeric timezone formats: "CET" or "+01:00". The first format is commonly
+    # used with the `TZ` envvar, which can be overriden by a more specific
+    # `DEFAULT_TIME_ZONE`.
+    #
+    # The default value is "+00:00".
+    #
+    if [[ -z $DEFAULT_TIME_ZONE ]]; then
+        if [[ -n $TZ ]]; then
+            DEFAULT_TIME_ZONE=$TZ
+        else
+            DEFAULT_TIME_ZONE="+00:00"
+        fi
+    fi
+fi
+
 # Set data directory permissions for later use of "gosu"
 chown mysql /var/lib/mysql
 
@@ -49,7 +76,7 @@ case "$1" in
 		set +e -m
 		gosu mysql mysqld.sh --console \
 			--wsrep-on=OFF \
-			--default-time-zone="+00:00" \
+			--default-time-zone=$DEFAULT_TIME_ZONE \
 			"$@" 2>&1 &
 		wait $! || true
 		exit
@@ -332,7 +359,7 @@ gosu mysql mysqld.sh --console \
 	--wsrep_cluster_name=$CLUSTER_NAME \
 	--wsrep_cluster_address=gcomm://$GCOMM \
 	--wsrep_node_address=$NODE_ADDRESS:4567 \
-	--default-time-zone=+00:00 \
+	--default-time-zone=$DEFAULT_TIME_ZONE \
 	"$@" 2>&1 &
 wait $! || true
 RC=$?


### PR DESCRIPTION
- Ability to override `--default-time-zone` parameter
- If we haven't skipped timezone tables generation with `SKIP_TZINFO`, then we look for the timezone setting in the `DEFAULT_TIME_ZONE` envvar. If undefined, we look at the commonly used `TZ` envvar. If still undefined, we default to "+00:00"
- If we have skipped timezone tables generation, we look directly at `DEFAULT_TIME_ZONE` envvar and fall back to default if it contains a non-numeric timezone (e.g. "CET")
- Fixes #29 