### PR TITLE
avoid socat TTY handling

### DIFF
--- a/mysqld.sh
+++ b/mysqld.sh
@@ -190,7 +190,7 @@ else
 			fi
 			for node in ${GCOMM//,/ }; do
 				[[ $node = $NODE_ADDRESS ]] && continue
-				if socat - TCP:$node:$LISTEN_PORT <<< "seqno:$NODE_ADDRESS:$POSITION:$SAFE_TO_BOOTSTRAP"; then
+				if socat - TCP:$node:$LISTEN_PORT <<< "seqno:$NODE_ADDRESS:$POSITION:$SAFE_TO_BOOTSTRAP" > /dev/null; then
 					SENT_NODES="$SENT_NODES,$node"
 				fi
 				if [[ -n $VIEW_ID ]]; then


### PR DESCRIPTION
This change makes it so that everything works properly even if the user ran with `docker -ti`.

`socat` detects whether stdout is a TTY and "helpfully" stores and restores TTY settings with `tcgetattr()` and `tcsetattr()`.  Upon the call to `tcsetattr()`, socat receives signal 22, SIGTTOU.  Docker (or some other parent process) seems to set the signal disposition for SIGTTOU to "terminate", and thus socat exits with status 150 (128 + 22).  This causes `SENT_NODES` not to be updated.  All that because the user thought they might want to run with `docker -ti` to watch the output while the cluster booted up.

Of course, the answer could be "don't run with --tty", but we don't actually need `socat`'s stdout and this change prevents the user from shooting their foot.