### PR TITLE
Implemented support for stacks with static hostnames for docker > 19.03

### DIFF
--- a/examples/stack/README.md
+++ b/examples/stack/README.md
@@ -1,0 +1,10 @@
+Allows you to assign predictable static hostnames to each container.
+This allows HAProxy to connect to each server reliably.
+
+Requires a version of docker > 19.03
+https://github.com/moby/moby/pull/39204
+
+docker network create -d overlay --attachable haproxy
+docker network create -d overlay --attachable galera
+docker stack deploy --compose-file docker-compose.yml galera
+

--- a/examples/stack/docker-compose.yml
+++ b/examples/stack/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+  node:
+    image: virtpanel/mariadb-galera-swarm
+    command: node tasks.galera-seed,galera_node
+    deploy:
+      replicas: 4
+    hostname: "{{.Service.Name}}.{{.Task.Slot}}"
+    networks:
+      - galera
+      - haproxy
+    volumes:
+      - type: bind
+        source: /d/galera/data
+        target: /var/lib/mysql
+      - type: bind
+        source: /mnt/gfs/galera/secrets
+        target: /run/secrets
+        read_only: true
+
+networks:
+  galera:
+    driver: overlay
+    external: true
+  haproxy:
+    driver: overlay
+    external: true
+


### PR DESCRIPTION
Deploying a stack will not work with the current release of docker, you need to have the next major release after 19.03.
More info: https://github.com/moby/moby/pull/39204

The magic that allows this to happen is adding a line into docker-compose.yml
hostname: "{{.Service.Name}}.{{.Task.Slot}}"

And voila, now external services such as haproxy can connect to your database servers (they must be on the same docker network in order to resolve the DNS).