### PR TITLE
Verify host addresses before adding IPs to GCOMM

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -323,7 +323,7 @@ case $START_MODE in
 					GCOMM+="$SEP$ADDR"
 				else
 					RESOLVE=1
-					GCOMM+="$SEP$(getent hosts "$ADDR" | awk '{ print $1 }' | paste -sd ",")"
+					GCOMM+="$SEP$(getent hosts "$ADDR" | awk -v addr="$ADDR" '$2 == addr { print $1 }' | paste -sd ",")"
 				fi
 				if [ -n "$GCOMM" ]; then
 					SEP=,


### PR DESCRIPTION
Early calls to `getent hosts` can return upstream DNS results that don't match the docker network subnet.

Resolves: #126
See also: #101